### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: JSON to plain text lib tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/sumithemmadi/json-to-plain-text/security/code-scanning/1](https://github.com/sumithemmadi/json-to-plain-text/security/code-scanning/1)

To fix the issue, explicitly set the `permissions` key to limit the permission scope granted to the `GITHUB_TOKEN` during the workflow execution. The most reliable way to do this is to add a `permissions:` block with `contents: read` either at the top of the workflow (preferably, so all jobs inherit it), or inside the `test` job definition if you want to limit scope to just this job. Given the provided snippet only contains a `test` job and no special needs, it is best practice to add the `permissions:` block right under the workflow `name:` at the top level, ensuring that all current and future jobs inherit this restriction by default. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
